### PR TITLE
Add Multi-Language Support (Swedish, Dutch, French)

### DIFF
--- a/i18n-issue.md
+++ b/i18n-issue.md
@@ -1,0 +1,54 @@
+# Add Multi-Language Support (Swedish, Dutch, French)
+
+## Overview
+We need to add internationalization (i18n) to the coffee-tracker application to support multiple languages: Swedish, Dutch, and French, in addition to English (default). This will make our application accessible to a wider audience.
+
+## Requirements
+
+### Translations
+- Translate all UI text content into:
+  - Swedish (Svenska)
+  - Dutch (Nederlands)
+  - French (Français)
+  - Keep English as the default language
+
+### User Interface
+- Add a language selector dropdown in the upper corner of the application
+- Use flag icons to represent each language:
+  - 🇸🇪 For Swedish
+  - 🇳🇱 For Dutch
+  - 🇫🇷 For French
+  - 🇬🇧 For English (default)
+- The selected language should be stored in user preferences/local storage
+- The application should load with the previously selected language on subsequent visits
+
+### Technical Implementation
+- Use Next.js Internationalization (i18n) routing features
+- Create a language context to manage the current language across the application
+- Implement translation files (JSON) for each supported language
+- All text, labels, buttons, notifications, and error messages should be translatable
+- Ensure date and number formats respect locale conventions
+
+### Affected Files
+- Layout components to include the language selector
+- All pages with user-visible text
+- API responses with user-visible messages
+
+## Acceptance Criteria
+- [ ] Language selector dropdown is visible in the upper corner with flag icons
+- [ ] Selecting a language immediately updates all text on the page
+- [ ] Language preference persists between sessions
+- [ ] All application text is properly translated in all supported languages
+- [ ] Date and time formats respect the selected language conventions
+- [ ] Code is well-documented with comments explaining the i18n implementation
+
+## Resources
+- Example flag icons can be added to the `/public` directory
+- Translation JSON files should be organized in a new `/src/translations` directory
+- Consider using `next-i18next` or a similar library for managing translations
+
+## Priority
+Medium
+
+## Estimated Effort
+3-4 days of development work

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "aws-cdk-lib": "^2.190.0",
         "constructs": "^10.4.2",
         "next": "15.3.1",
+        "next-intl": "^4.0.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "sst": "^2.48.5"
@@ -4061,6 +4062,66 @@
         "node": ">=14"
       }
     },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
+      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.1",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
+      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
+      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/icu-skeleton-parser": "1.8.14",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
+      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.10.tgz",
+      "integrity": "sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
+      }
+    },
     "node_modules/@graphql-tools/executor": {
       "version": "0.0.18",
       "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-0.0.18.tgz",
@@ -5842,6 +5903,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.11.0.tgz",
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
       "dev": true
+    },
+    "node_modules/@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+      "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -25548,6 +25615,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "license": "MIT"
+    },
     "node_modules/dedent": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
@@ -28330,6 +28403,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.16",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
+      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/ip-address": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
@@ -30933,6 +31018,42 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-intl": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.0.2.tgz",
+      "integrity": "sha512-3cKVflwdrqxCOvAL+DtGN68qR802i0PEj0dttkAD5IK5XxOjugQs4yU8aSakvPMbkOrhEJ+89z5lG2EAqi7Gkw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.5.4",
+        "negotiator": "^1.0.0",
+        "use-intl": "^4.0.2"
+      },
+      "peerDependencies": {
+        "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0",
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/next-tick": {
@@ -35902,6 +36023,20 @@
       "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
       "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
       "license": "MIT"
+    },
+    "node_modules/use-intl": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.0.2.tgz",
+      "integrity": "sha512-6RAP/5KJMRzLMLS25/BVh2u09cRK8S6HRGc1RnZvqR547qAKZCpjYylOqMPU9eNIirAiKoGmsoUPa7JrlaA/yg==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^2.2.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "intl-messageformat": "^10.5.14"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
+      }
     },
     "node_modules/util": {
       "version": "0.12.5",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "aws-cdk-lib": "^2.190.0",
     "constructs": "^10.4.2",
     "next": "15.3.1",
+    "next-intl": "^4.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sst": "^2.48.5"

--- a/src/app/coffee/[id]/page.tsx
+++ b/src/app/coffee/[id]/page.tsx
@@ -15,9 +15,12 @@ import {
   Alert,
 } from '@mui/material';
 import { CoffeeEntry } from '@/types/coffee';
+import { useTranslation, useLanguage } from '@/context/LanguageContext';
 
 export default function CoffeeEntryPage({ params }: { params: { id: string } }) {
   const router = useRouter();
+  const { t } = useTranslation();
+  const { language } = useLanguage();
   const [entry, setEntry] = useState<CoffeeEntry | null>(null);
   const [loading, setLoading] = useState(true);
   const [rating, setRating] = useState<number | null>(null);
@@ -48,15 +51,15 @@ export default function CoffeeEntryPage({ params }: { params: { id: string } }) 
         setRating(data.rating || null);
         setLocation(data.location || '');
       } else {
-        showNotification('Coffee entry not found', 'error');
+        showNotification(t('notifications.notFound'), 'error');
       }
     } catch (error) {
       console.error('Error fetching entry:', error);
-      showNotification('Failed to load coffee entry', 'error');
+      showNotification(t('notifications.loadError'), 'error');
     } finally {
       setLoading(false);
     }
-  }, [params.id, showNotification]);
+  }, [params.id, showNotification, t]);
 
   useEffect(() => {
     fetchEntry();
@@ -79,7 +82,7 @@ export default function CoffeeEntryPage({ params }: { params: { id: string } }) 
       if (response.ok) {
         const updatedEntry = await response.json();
         setEntry(updatedEntry);
-        showNotification('Coffee entry updated successfully', 'success');
+        showNotification(t('notifications.updateSuccess'), 'success');
         
         // Delay navigation to allow user to see the success notification
         setTimeout(() => {
@@ -87,11 +90,11 @@ export default function CoffeeEntryPage({ params }: { params: { id: string } }) 
         }, 1500); // 1.5 seconds delay before navigation
       } else {
         const error = await response.json();
-        showNotification(error.error || 'Failed to update coffee entry', 'error');
+        showNotification(error.error || t('notifications.updateError'), 'error');
       }
     } catch (error) {
       console.error('Error updating entry:', error);
-      showNotification('Failed to update coffee entry', 'error');
+      showNotification(t('notifications.updateError'), 'error');
     } finally {
       setSaving(false);
     }
@@ -102,7 +105,13 @@ export default function CoffeeEntryPage({ params }: { params: { id: string } }) 
   };
 
   const formatDate = (timestamp: string) => {
-    return new Date(timestamp).toLocaleString();
+    // Format date according to the current language locale
+    return new Date(timestamp).toLocaleString(
+      language === 'en' ? 'en-US' : 
+      language === 'sv' ? 'sv-SE' : 
+      language === 'nl' ? 'nl-NL' : 
+      'fr-FR'
+    );
   };
 
   if (loading) {
@@ -119,13 +128,13 @@ export default function CoffeeEntryPage({ params }: { params: { id: string } }) 
     return (
       <Container maxWidth="sm">
         <Paper sx={{ p: 3, my: 4 }}>
-          <Typography variant="h6">Coffee entry not found</Typography>
+          <Typography variant="h6">{t('notifications.notFound')}</Typography>
           <Button
             variant="contained"
             onClick={() => router.push('/')}
             sx={{ mt: 2 }}
           >
-            Back to Home
+            {t('details.backHome')}
           </Button>
         </Paper>
       </Container>
@@ -136,7 +145,7 @@ export default function CoffeeEntryPage({ params }: { params: { id: string } }) 
     <Container maxWidth="sm">
       <Box sx={{ my: 4 }}>
         <Typography variant="h4" component="h1" gutterBottom align="center">
-          Coffee Details
+          {t('details.title')}
         </Typography>
 
         <Paper sx={{ p: 3, mb: 3 }}>
@@ -151,16 +160,16 @@ export default function CoffeeEntryPage({ params }: { params: { id: string } }) 
 
           <Box sx={{ mb: 3 }}>
             <TextField
-              label="Location"
+              label={t('details.location')}
               value={location}
               onChange={(e) => setLocation(e.target.value)}
               fullWidth
-              placeholder="Where did you have this coffee?"
+              placeholder={t('details.locationPlaceholder')}
               sx={{ mb: 2 }}
             />
             
             <Typography component="legend" sx={{ mt: 1 }}>
-              Rating
+              {t('details.rating')}
             </Typography>
             <MuiRating
               name="coffee-rating"
@@ -179,14 +188,14 @@ export default function CoffeeEntryPage({ params }: { params: { id: string } }) 
               disabled={saving}
               fullWidth
             >
-              {saving ? 'Saving...' : 'Save Changes'}
+              {saving ? t('common.saving') : t('common.save')}
             </Button>
             <Button
               variant="outlined"
               onClick={() => router.push('/')}
               fullWidth
             >
-              Back
+              {t('common.back')}
             </Button>
           </Box>
         </Paper>

--- a/src/app/coffee/[id]/page.tsx
+++ b/src/app/coffee/[id]/page.tsx
@@ -17,7 +17,7 @@ import {
 import { CoffeeEntry } from '@/types/coffee';
 import { useTranslation, useLanguage } from '@/context/LanguageContext';
 
-export default function CoffeeEntryPage({ params }: { params: { id: string } }) {
+export default function CoffeeEntryPage({ params }: { params: Promise<{ id: string }>}) {
   const router = useRouter();
   const { t } = useTranslation();
   const { language } = useLanguage();
@@ -43,7 +43,8 @@ export default function CoffeeEntryPage({ params }: { params: { id: string } }) 
   const fetchEntry = useCallback(async () => {
     try {
       setLoading(true);
-      const response = await fetch(`/api/coffee/${params.id}`);
+      const { id } = await params;
+      const response = await fetch(`/api/coffee/${id}`);
       
       if (response.ok) {
         const data = await response.json();
@@ -59,7 +60,7 @@ export default function CoffeeEntryPage({ params }: { params: { id: string } }) 
     } finally {
       setLoading(false);
     }
-  }, [params.id, showNotification, t]);
+  }, [params, showNotification, t]);
 
   useEffect(() => {
     fetchEntry();
@@ -68,7 +69,8 @@ export default function CoffeeEntryPage({ params }: { params: { id: string } }) 
   const handleSave = async () => {
     try {
       setSaving(true);
-      const response = await fetch(`/api/coffee/${params.id}`, {
+      const { id } = await params;
+      const response = await fetch(`/api/coffee/${id}`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { Geist, Geist_Mono } from "next/font/google";
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import "./globals.css";
+import { LanguageProvider } from "@/context/LanguageContext";
+import LanguageSelector from "@/components/LanguageSelector";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -38,7 +40,10 @@ export default function RootLayout({
       >
         <ThemeProvider theme={theme}>
           <CssBaseline />
-          {children}
+          <LanguageProvider>
+            <LanguageSelector />
+            {children}
+          </LanguageProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,8 +23,11 @@ import {
   Rating as MuiRating,
 } from '@mui/material';
 import type { MeasurementSystem, Unit, CoffeeEntry } from '../types/coffee';
+import { useTranslation, useLanguage } from '@/context/LanguageContext';
 
 export default function Home() {
+  const { t } = useTranslation();
+  const { language } = useLanguage();
   const [amount, setAmount] = useState<string>('');
   const [unit, setUnit] = useState<Unit>('cups');
   const [measurementSystem, setMeasurementSystem] = useState<MeasurementSystem>('metric');
@@ -80,7 +83,13 @@ export default function Home() {
   };
 
   const formatDate = (timestamp: string) => {
-    return new Date(timestamp).toLocaleString();
+    // Format date according to the current language
+    return new Date(timestamp).toLocaleString(
+      language === 'en' ? 'en-US' : 
+      language === 'sv' ? 'sv-SE' : 
+      language === 'nl' ? 'nl-NL' : 
+      'fr-FR'
+    );
   };
 
   const formatAmount = (amount: number, unit: Unit) => {
@@ -91,7 +100,10 @@ export default function Home() {
     <Container maxWidth="sm">
       <Box sx={{ my: 4 }}>
         <Typography variant="h4" component="h1" gutterBottom align="center">
-          Coffee Tracker
+          {t('home.title')}
+        </Typography>
+        <Typography variant="subtitle1" align="center" gutterBottom>
+          {t('home.subtitle')}
         </Typography>
         
         <Paper sx={{ p: 3, mb: 3 }}>
@@ -109,7 +121,7 @@ export default function Home() {
 
           <Box sx={{ display: 'flex', gap: 2, mb: 3 }}>
             <TextField
-              label="Amount"
+              label={t('home.amountLabel')}
               type="number"
               value={amount}
               onChange={(e) => setAmount(e.target.value)}
@@ -117,10 +129,10 @@ export default function Home() {
             />
             
             <FormControl sx={{ minWidth: 120 }}>
-              <InputLabel>Unit</InputLabel>
+              <InputLabel>{t('home.unitLabel')}</InputLabel>
               <Select
                 value={unit}
-                label="Unit"
+                label={t('home.unitLabel')}
                 onChange={(e) => setUnit(e.target.value as Unit)}
               >
                 {measurementSystem === 'metric' ? (
@@ -138,16 +150,16 @@ export default function Home() {
           {/* New fields for rating and location */}
           <Box sx={{ mb: 3 }}>
             <TextField
-              label="Location (optional)"
+              label={t('details.location') + ' (' + t('common.optional') + ')'}
               value={location}
               onChange={(e) => setLocation(e.target.value)}
               fullWidth
-              placeholder="Where did you have this coffee?"
+              placeholder={t('details.locationPlaceholder')}
               sx={{ mb: 2 }}
             />
             
             <Typography component="legend" sx={{ mt: 1 }}>
-              Rating (optional)
+              {t('details.rating')} ({t('common.optional')})
             </Typography>
             <MuiRating
               name="coffee-rating"
@@ -165,13 +177,13 @@ export default function Home() {
             fullWidth
             disabled={!amount}
           >
-            Add Coffee
+            {t('home.addCoffee')}
           </Button>
         </Paper>
 
         <Paper sx={{ p: 3 }}>
           <Typography variant="h6" gutterBottom>
-            Recent Entries
+            {t('home.recentEntries')}
           </Typography>
           <List>
             {entries.map((entry, index) => (
@@ -195,7 +207,7 @@ export default function Home() {
                         {formatDate(entry.timestamp)}
                         {entry.location && (
                           <Typography variant="body2" component="span" display="block">
-                            Location: {entry.location}
+                            {t('details.location')}: {entry.location}
                           </Typography>
                         )}
                       </>
@@ -207,7 +219,7 @@ export default function Home() {
             ))}
             {entries.length === 0 && (
               <ListItem>
-                <ListItemText primary="No entries yet" />
+                <ListItemText primary={t('home.noCoffee')} />
               </ListItem>
             )}
           </List>

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -19,7 +19,7 @@ const languageOptions: { code: Language; flag: string; name: string }[] = [
 ];
 
 export default function LanguageSelector() {
-  const { language, setLanguage, translations } = useLanguage();
+  const { language, setLanguage } = useLanguage();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
 

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useState } from 'react';
+import { 
+  Box,
+  Menu,
+  MenuItem,
+  IconButton,
+  Typography
+} from '@mui/material';
+import { useLanguage, Language } from '../context/LanguageContext';
+
+// Define language options with their flags and names
+const languageOptions: { code: Language; flag: string; name: string }[] = [
+  { code: 'en', flag: '🇬🇧', name: 'English' },
+  { code: 'sv', flag: '🇸🇪', name: 'Svenska' },
+  { code: 'nl', flag: '🇳🇱', name: 'Nederlands' },
+  { code: 'fr', flag: '🇫🇷', name: 'Français' },
+];
+
+export default function LanguageSelector() {
+  const { language, setLanguage, translations } = useLanguage();
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  // Get the current language option
+  const currentLanguage = languageOptions.find((option) => option.code === language) || languageOptions[0];
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleLanguageSelect = (code: Language) => {
+    setLanguage(code);
+    handleClose();
+  };
+
+  return (
+    <Box sx={{ position: 'absolute', top: 16, right: 16 }}>
+      <IconButton
+        onClick={handleClick}
+        aria-controls={open ? 'language-menu' : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        sx={{ 
+          border: '1px solid #ddd', 
+          borderRadius: 2, 
+          px: 1, 
+          py: 0.5,
+          backgroundColor: 'background.paper',
+          '&:hover': {
+            backgroundColor: 'action.hover',
+          },
+        }}
+      >
+        <Typography variant="body2" sx={{ mr: 1 }}>
+          {currentLanguage.flag}
+        </Typography>
+        <Typography variant="body2">
+          {currentLanguage.code.toUpperCase()}
+        </Typography>
+      </IconButton>
+      
+      <Menu
+        id="language-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        MenuListProps={{
+          'aria-labelledby': 'language-button',
+        }}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+      >
+        {languageOptions.map((option) => (
+          <MenuItem 
+            key={option.code} 
+            onClick={() => handleLanguageSelect(option.code)}
+            selected={option.code === language}
+          >
+            <Typography variant="body2" sx={{ mr: 1 }}>
+              {option.flag}
+            </Typography>
+            <Typography variant="body2">
+              {option.name}
+            </Typography>
+          </MenuItem>
+        ))}
+      </Menu>
+    </Box>
+  );
+}

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+
+// Define supported languages
+export type Language = 'en' | 'sv' | 'nl' | 'fr';
+
+// Define the language context type
+interface LanguageContextType {
+  language: Language;
+  setLanguage: (language: Language) => void;
+  translations: Record<string, any>;
+}
+
+// Create the language context with default values
+const LanguageContext = createContext<LanguageContextType>({
+  language: 'en',
+  setLanguage: () => {},
+  translations: {},
+});
+
+interface LanguageProviderProps {
+  children: ReactNode;
+}
+
+export const LanguageProvider = ({ children }: LanguageProviderProps) => {
+  // Initialize language state from localStorage or default to 'en'
+  const [language, setLanguage] = useState<Language>('en');
+  const [translations, setTranslations] = useState<Record<string, any>>({});
+
+  // Load translations for the current language
+  useEffect(() => {
+    const loadTranslations = async () => {
+      try {
+        // Import the translation file dynamically
+        const translationModule = await import(`../translations/${language}.json`);
+        setTranslations(translationModule.default);
+      } catch (error) {
+        console.error(`Failed to load translations for ${language}`, error);
+        // Fallback to English if loading fails
+        if (language !== 'en') {
+          const enTranslations = await import('../translations/en.json');
+          setTranslations(enTranslations.default);
+        }
+      }
+    };
+
+    loadTranslations();
+  }, [language]);
+
+  // Update language and store in localStorage
+  const handleSetLanguage = (newLanguage: Language) => {
+    setLanguage(newLanguage);
+    localStorage.setItem('preferredLanguage', newLanguage);
+  };
+
+  // Initialize from localStorage on first render (client-side only)
+  useEffect(() => {
+    const savedLanguage = localStorage.getItem('preferredLanguage') as Language | null;
+    if (savedLanguage && ['en', 'sv', 'nl', 'fr'].includes(savedLanguage)) {
+      setLanguage(savedLanguage);
+    }
+  }, []);
+
+  return (
+    <LanguageContext.Provider 
+      value={{ 
+        language, 
+        setLanguage: handleSetLanguage, 
+        translations 
+      }}
+    >
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+// Custom hook to use the language context
+export const useLanguage = () => useContext(LanguageContext);
+
+// Helper function to get a translation by key
+export const useTranslation = () => {
+  const { translations } = useLanguage();
+  
+  const t = (key: string) => {
+    // Split the key into parts (e.g., "common.save" -> ["common", "save"])
+    const parts = key.split('.');
+    
+    // Navigate through the translations object
+    let value = translations;
+    for (const part of parts) {
+      if (value && typeof value === 'object' && part in value) {
+        value = value[part];
+      } else {
+        // Return the key if translation not found
+        return key;
+      }
+    }
+    
+    return value;
+  };
+  
+  return { t };
+};

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -5,11 +5,14 @@ import React, { createContext, useContext, useState, useEffect, ReactNode } from
 // Define supported languages
 export type Language = 'en' | 'sv' | 'nl' | 'fr';
 
+// Define translation record type
+export type TranslationRecord = Record<string, string | TranslationRecord>;
+
 // Define the language context type
 interface LanguageContextType {
   language: Language;
   setLanguage: (language: Language) => void;
-  translations: Record<string, any>;
+  translations: TranslationRecord;
 }
 
 // Create the language context with default values
@@ -26,7 +29,7 @@ interface LanguageProviderProps {
 export const LanguageProvider = ({ children }: LanguageProviderProps) => {
   // Initialize language state from localStorage or default to 'en'
   const [language, setLanguage] = useState<Language>('en');
-  const [translations, setTranslations] = useState<Record<string, any>>({});
+  const [translations, setTranslations] = useState<TranslationRecord>({});
 
   // Load translations for the current language
   useEffect(() => {
@@ -87,17 +90,17 @@ export const useTranslation = () => {
     const parts = key.split('.');
     
     // Navigate through the translations object
-    let value = translations;
+    let value: unknown = translations;
     for (const part of parts) {
-      if (value && typeof value === 'object' && part in value) {
-        value = value[part];
+      if (value && typeof value === 'object' && part in (value as object)) {
+        value = (value as Record<string, unknown>)[part];
       } else {
         // Return the key if translation not found
         return key;
       }
     }
     
-    return value;
+    return value as string;
   };
   
   return { t };

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,0 +1,33 @@
+{
+  "common": {
+    "appTitle": "Coffee Tracker",
+    "save": "Save Changes",
+    "back": "Back",
+    "saving": "Saving...",
+    "language": "Language",
+    "optional": "optional"
+  },
+  "home": {
+    "title": "Coffee Tracker",
+    "subtitle": "Track your coffee consumption",
+    "addCoffee": "Add Coffee",
+    "noCoffee": "No coffee entries yet. Add one!",
+    "totalToday": "Total Today:",
+    "amountLabel": "Amount",
+    "unitLabel": "Unit",
+    "recentEntries": "Recent Entries"
+  },
+  "details": {
+    "title": "Coffee Details",
+    "location": "Location",
+    "locationPlaceholder": "Where did you have this coffee?",
+    "rating": "Rating",
+    "backHome": "Back to Home"
+  },
+  "notifications": {
+    "updateSuccess": "Coffee entry updated successfully",
+    "updateError": "Failed to update coffee entry",
+    "loadError": "Failed to load coffee entry",
+    "notFound": "Coffee entry not found"
+  }
+}

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -1,0 +1,33 @@
+{
+  "common": {
+    "appTitle": "Suivi de Café",
+    "save": "Enregistrer les modifications",
+    "back": "Retour",
+    "saving": "Enregistrement...",
+    "language": "Langue",
+    "optional": "optionnel"
+  },
+  "home": {
+    "title": "Suivi de Café",
+    "subtitle": "Suivez votre consommation de café",
+    "addCoffee": "Ajouter un café",
+    "noCoffee": "Pas encore d'entrées de café. Ajoutez-en une !",
+    "totalToday": "Total aujourd'hui :",
+    "amountLabel": "Quantité",
+    "unitLabel": "Unité",
+    "recentEntries": "Entrées récentes"
+  },
+  "details": {
+    "title": "Détails du café",
+    "location": "Lieu",
+    "locationPlaceholder": "Où avez-vous pris ce café ?",
+    "rating": "Évaluation",
+    "backHome": "Retour à l'accueil"
+  },
+  "notifications": {
+    "updateSuccess": "Entrée de café mise à jour avec succès",
+    "updateError": "Échec de la mise à jour de l'entrée de café",
+    "loadError": "Échec du chargement de l'entrée de café",
+    "notFound": "Entrée de café introuvable"
+  }
+}

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -1,0 +1,33 @@
+{
+  "common": {
+    "appTitle": "Koffie Tracker",
+    "save": "Wijzigingen opslaan",
+    "back": "Terug",
+    "saving": "Opslaan...",
+    "language": "Taal",
+    "optional": "optioneel"
+  },
+  "home": {
+    "title": "Koffie Tracker",
+    "subtitle": "Volg je koffieconsumptie",
+    "addCoffee": "Koffie toevoegen",
+    "noCoffee": "Nog geen koffie-invoer. Voeg er een toe!",
+    "totalToday": "Totaal vandaag:",
+    "amountLabel": "Hoeveelheid",
+    "unitLabel": "Eenheid",
+    "recentEntries": "Recente invoer"
+  },
+  "details": {
+    "title": "Koffiedetails",
+    "location": "Locatie",
+    "locationPlaceholder": "Waar heb je deze koffie gedronken?",
+    "rating": "Beoordeling",
+    "backHome": "Terug naar begin"
+  },
+  "notifications": {
+    "updateSuccess": "Koffie-invoer succesvol bijgewerkt",
+    "updateError": "Kon koffie-invoer niet bijwerken",
+    "loadError": "Kon koffie-invoer niet laden",
+    "notFound": "Koffie-invoer niet gevonden"
+  }
+}

--- a/src/translations/sv.json
+++ b/src/translations/sv.json
@@ -1,0 +1,33 @@
+{
+  "common": {
+    "appTitle": "Kafferäknare",
+    "save": "Spara ändringar",
+    "back": "Tillbaka",
+    "saving": "Sparar...",
+    "language": "Språk",
+    "optional": "valfri"
+  },
+  "home": {
+    "title": "Kafferäknare",
+    "subtitle": "Håll koll på din kaffekonsumtion",
+    "addCoffee": "Lägg till kaffe",
+    "noCoffee": "Inga kaffeanteckningar än. Lägg till en!",
+    "totalToday": "Totalt idag:",
+    "amountLabel": "Mängd",
+    "unitLabel": "Enhet",
+    "recentEntries": "Senaste anteckningar"
+  },
+  "details": {
+    "title": "Kaffedetaljer",
+    "location": "Plats",
+    "locationPlaceholder": "Var drack du detta kaffe?",
+    "rating": "Betyg",
+    "backHome": "Tillbaka till start"
+  },
+  "notifications": {
+    "updateSuccess": "Kaffepost uppdaterades",
+    "updateError": "Kunde inte uppdatera kaffepost",
+    "loadError": "Kunde inte ladda kaffepost",
+    "notFound": "Kaffepost hittades inte"
+  }
+}


### PR DESCRIPTION
Resolves #3. 

This PR adds internationalization (i18n) support to the coffee-tracker application with the following languages:
- English (default)
- Swedish
- Dutch
- French

## Implementation
- Added language selector dropdown in the upper right corner with flag icons (🇬🇧 🇸🇪 🇳🇱 🇫🇷)
- Created translation files for all supported languages
- Implemented language context provider to manage language selection
- Updated all UI text to use translated strings
- Added locale-aware date formatting
- User language preferences are stored in local storage

## Testing
- Verified language switching works across all pages
- Confirmed translations are displayed correctly
- Validated that language preference persists between sessions
